### PR TITLE
Update build to use requirements.txt file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@ FROM alpine
 RUN apk --update add \
     make \
     git \
-    py3-sphinx \
-    py3-sphinx-autobuild \
     py3-pip \
     && rm -rf /var/cache/apk/*
 
-RUN pip3 install -e \
-    git+https://github.com/readthedocs/sphinx_rtd_theme.git@ab7d388448258a24f8f4fa96dccb69d24f571736#egg=sphinx_rtd_theme \
-    git+https://github.com/humitos/sphinx-version-warning@master
+# python virtualenv
+RUN python -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
 
 EXPOSE 8000
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+python-dotenv
+readthedocs-sphinx-search==0.3.1
+sphinx==7.2.6
+sphinx-autobuild
+sphinx_rtd_theme==1.3.0
+sphinx-version-warning


### PR DESCRIPTION
python3 protects system python libs. This adds
* python virtualenv
* swap to using requirements.txt

moving everything into the requirements, including python-dotenv